### PR TITLE
build: run prisma migrations before build

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,9 @@ A production-grade starter tailored for pet-food manufacturing ERP. It implement
 ## Deploy on Hostinger (Node app)
 1. **MySQL**: create a database & user; whitelist your app; note connection details.
 2. Set environment variables in Hostinger dashboard (`DATABASE_URL`, `AUTH_SECRET`, `NEXTAUTH_URL`).
-3. Build the app:
+3. Build the app (runs Prisma migrations automatically):
    ```bash
    npm ci
-   npx prisma migrate deploy
    npm run build
    npm start
    ```

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev -p 3000",
-    "build": "prisma generate && next build",
+    "build": "prisma migrate deploy && prisma generate && next build",
     "start": "next start -p 3000",
     "postinstall": "prisma generate",
     "seed": "tsx seed.ts",


### PR DESCRIPTION
## Summary
- run Prisma migrations during build
- document Hostinger deploy process to rely on build script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b09d9707708328bab6e21c652247cd