### PR TITLE
Exclude health check from auth middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -2,6 +2,6 @@ export { auth as middleware } from '@/auth'
 
 export const config = {
   matcher: [
-    "/((?!api/auth|_next/static|_next/image|favicon.ico|login).*)"
+    "/((?!api/(auth|health)|_next/static|_next/image|favicon.ico|login).*)"
   ],
 }


### PR DESCRIPTION
## Summary
- allow unauthenticated access to `/api/health`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b09d929cd483289496d1d708a61cea