### PR TITLE
Add inventory transactions for orders and production batches

### DIFF
--- a/app/api/batches/route.ts
+++ b/app/api/batches/route.ts
@@ -1,12 +1,17 @@
 import { prisma } from '@/lib/prisma'
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
+import { BatchStatus, LotStatus } from '@prisma/client'
 
 const schema = z.object({
   fgItemId: z.string().min(1),
   batchNumber: z.string().min(1),
   plannedQty: z.number(),
   uom: z.string().min(1)
+})
+
+const completeSchema = z.object({
+  batchId: z.string().min(1)
 })
 
 export async function GET() {
@@ -28,3 +33,49 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: e.message }, { status: 500 })
   }
 }
+
+export async function PUT(req: Request) {
+  const data = await req.json()
+  const parsed = completeSchema.safeParse(data)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.format() }, { status: 400 })
+  try {
+    const updated = await prisma.$transaction(async tx => {
+      const batch = await tx.productionBatch.findUnique({ where: { id: parsed.data.batchId } })
+      if (!batch) throw new Error('Batch not found')
+      const formulation = await tx.formulation.findFirst({
+        where: { itemId: batch.fgItemId },
+        include: { lines: true }
+      })
+      if (!formulation) throw new Error('Formulation not found')
+      for (const line of formulation.lines) {
+        const required = line.qty * batch.plannedQty
+        const lot = await tx.inventoryLot.findFirst({
+          where: { itemId: line.childId, status: LotStatus.RELEASED, qty: { gte: required } },
+          orderBy: { createdAt: 'asc' }
+        })
+        if (!lot) throw new Error(`Insufficient stock for component ${line.childId}`)
+        await tx.inventoryLot.update({
+          where: { id: lot.id },
+          data: { qty: { decrement: required } }
+        })
+      }
+      await tx.inventoryLot.create({
+        data: {
+          itemId: batch.fgItemId,
+          lotNumber: batch.batchNumber,
+          qty: batch.plannedQty,
+          uom: batch.uom,
+          status: LotStatus.QUARANTINE
+        }
+      })
+      return tx.productionBatch.update({
+        where: { id: batch.id },
+        data: { status: BatchStatus.COMPLETED, finishedAt: new Date() }
+      })
+    })
+    return NextResponse.json(updated)
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  }
+}
+

--- a/app/api/lots/route.ts
+++ b/app/api/lots/route.ts
@@ -1,0 +1,34 @@
+import { prisma } from '@/lib/prisma'
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { LotStatus } from '@prisma/client'
+
+const schema = z.object({
+  itemId: z.string().min(1),
+  lotNumber: z.string().min(1),
+  qty: z.number(),
+  uom: z.string().min(1),
+  status: z.nativeEnum(LotStatus),
+  binId: z.string().optional()
+})
+
+export async function GET() {
+  const lots = await prisma.inventoryLot.findMany({
+    include: { item: true, bin: { include: { warehouse: true } } },
+    orderBy: { createdAt: 'desc' }
+  })
+  return NextResponse.json(lots)
+}
+
+export async function POST(req: Request) {
+  const data = await req.json()
+  const parsed = schema.safeParse(data)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.format() }, { status: 400 })
+  try {
+    const lot = await prisma.inventoryLot.create({ data: parsed.data })
+    return NextResponse.json(lot)
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  }
+}
+

--- a/app/api/sales/route.ts
+++ b/app/api/sales/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/lib/prisma'
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
+import { SOStatus, LotStatus } from '@prisma/client'
 
 const lineSchema = z.object({
   itemId: z.string().min(1),
@@ -12,6 +13,10 @@ const schema = z.object({
   orderNo: z.string().min(1),
   customerName: z.string().min(1),
   lines: z.array(lineSchema).min(1)
+})
+
+const confirmSchema = z.object({
+  orderId: z.string().min(1)
 })
 
 export async function GET() {
@@ -46,3 +51,38 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: e.message }, { status: 500 })
   }
 }
+
+export async function PUT(req: Request) {
+  const data = await req.json()
+  const parsed = confirmSchema.safeParse(data)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.format() }, { status: 400 })
+  try {
+    const updated = await prisma.$transaction(async tx => {
+      const order = await tx.salesOrder.findUnique({
+        where: { id: parsed.data.orderId },
+        include: { lines: true }
+      })
+      if (!order) throw new Error('Order not found')
+      for (const line of order.lines) {
+        const lot = await tx.inventoryLot.findFirst({
+          where: { itemId: line.itemId, status: LotStatus.RELEASED, qty: { gte: line.qty } },
+          orderBy: { createdAt: 'asc' }
+        })
+        if (!lot) throw new Error(`Insufficient stock for item ${line.itemId}`)
+        await tx.inventoryLot.update({
+          where: { id: lot.id },
+          data: { qty: { decrement: line.qty } }
+        })
+      }
+      return tx.salesOrder.update({
+        where: { id: order.id },
+        data: { status: SOStatus.CONFIRMED },
+        include: { customer: true, lines: { include: { item: true } } }
+      })
+    })
+    return NextResponse.json(updated)
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  }
+}
+


### PR DESCRIPTION
## Summary
- add lot API to create and list inventory lots
- decrement stock when confirming sales orders
- consume component lots and create finished-goods lot on batch completion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1c8185dd88328b7ca4613e5260ff4