### PR TITLE
Add service ticket workflow and APIs

### DIFF
--- a/AssignTicketForm.tsx
+++ b/AssignTicketForm.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useState } from 'react'
+import axios from 'axios'
+
+interface Option { id: string; name: string }
+
+export default function AssignTicketForm({ ticketId, users }: { ticketId: string; users: Option[] }) {
+  const [userId, setUserId] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [msg, setMsg] = useState<string | null>(null)
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    setLoading(true); setMsg(null)
+    const res = await axios.post(`/api/services/${ticketId}/assign`, { userId })
+    setLoading(false)
+    if (res.status === 200) {
+      setMsg('Assigned')
+      window.location.href = '/services'
+    } else setMsg('Failed')
+  }
+
+  return (
+    <form onSubmit={submit} className="space-y-3">
+      <div>
+        <label className="label">Assign To</label>
+        <select className="input" value={userId} onChange={e=>setUserId(e.target.value)} required>
+          <option value="">Select user</option>
+          {users.map(u => <option key={u.id} value={u.id}>{u.name}</option>)}
+        </select>
+      </div>
+      <button className="btn" disabled={loading}>{loading ? 'Saving...' : 'Assign'}</button>
+      {msg && <div className="text-sm text-gray-500">{msg}</div>}
+    </form>
+  )
+}
+

--- a/CloseTicketForm.tsx
+++ b/CloseTicketForm.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useState } from 'react'
+import axios from 'axios'
+
+export default function CloseTicketForm({ ticketId }: { ticketId: string }) {
+  const [resolution, setResolution] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [msg, setMsg] = useState<string | null>(null)
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    setLoading(true); setMsg(null)
+    const res = await axios.post(`/api/services/${ticketId}/close`, { resolution })
+    setLoading(false)
+    if (res.status === 200) {
+      setMsg('Closed')
+      window.location.href = '/services'
+    } else setMsg('Failed')
+  }
+
+  return (
+    <form onSubmit={submit} className="space-y-3">
+      <div>
+        <label className="label">Resolution</label>
+        <textarea className="input" value={resolution} onChange={e=>setResolution(e.target.value)} />
+      </div>
+      <button className="btn" disabled={loading}>{loading ? 'Saving...' : 'Close Ticket'}</button>
+      {msg && <div className="text-sm text-gray-500">{msg}</div>}
+    </form>
+  )
+}
+

--- a/NewTicketForm.tsx
+++ b/NewTicketForm.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { useState } from 'react'
+import axios from 'axios'
+
+interface Option { id: string; name: string }
+
+export default function NewTicketForm({ customers, items }: { customers: Option[]; items: Option[] }) {
+  const [form, setForm] = useState({ customerId: '', itemId: '', description: '' })
+  const [loading, setLoading] = useState(false)
+  const [msg, setMsg] = useState<string | null>(null)
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    setLoading(true); setMsg(null)
+    const res = await axios.post('/api/services', form)
+    setLoading(false)
+    if (res.status === 200) {
+      setMsg('Created')
+      setForm({ customerId: '', itemId: '', description: '' })
+      window.location.href = '/services'
+    } else setMsg('Failed')
+  }
+
+  return (
+    <form onSubmit={submit} className="space-y-3">
+      <div>
+        <label className="label">Customer</label>
+        <select className="input" value={form.customerId} onChange={e=>setForm({...form, customerId:e.target.value})} required>
+          <option value="">Select customer</option>
+          {customers.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
+        </select>
+      </div>
+      <div>
+        <label className="label">Item</label>
+        <select className="input" value={form.itemId} onChange={e=>setForm({...form, itemId:e.target.value})} required>
+          <option value="">Select item</option>
+          {items.map(i => <option key={i.id} value={i.id}>{i.name}</option>)}
+        </select>
+      </div>
+      <div>
+        <label className="label">Description</label>
+        <textarea className="input" value={form.description} onChange={e=>setForm({...form, description:e.target.value})} />
+      </div>
+      <button className="btn" disabled={loading}>{loading ? 'Saving...' : 'Create Ticket'}</button>
+      {msg && <div className="text-sm text-gray-500">{msg}</div>}
+    </form>
+  )
+}
+

--- a/app/api/services/[id]/assign/route.ts
+++ b/app/api/services/[id]/assign/route.ts
@@ -1,0 +1,27 @@
+import { prisma } from '@/lib/prisma'
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { TicketStatus } from '@prisma/client'
+
+const schema = z.object({
+  userId: z.string().min(1)
+})
+
+export async function POST(req: Request, { params }: { params: { id: string } }) {
+  const data = await req.json()
+  const parsed = schema.safeParse(data)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.format() }, { status: 400 })
+  }
+  try {
+    const ticket = await prisma.serviceTicket.update({
+      where: { id: params.id },
+      data: { assignedToId: parsed.data.userId, status: TicketStatus.ASSIGNED },
+      include: { customer: true, item: true, assignedTo: true }
+    })
+    return NextResponse.json(ticket)
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  }
+}
+

--- a/app/api/services/[id]/close/route.ts
+++ b/app/api/services/[id]/close/route.ts
@@ -1,0 +1,27 @@
+import { prisma } from '@/lib/prisma'
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { TicketStatus } from '@prisma/client'
+
+const schema = z.object({
+  resolution: z.string().optional()
+})
+
+export async function POST(req: Request, { params }: { params: { id: string } }) {
+  const data = await req.json().catch(() => ({}))
+  const parsed = schema.safeParse(data)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.format() }, { status: 400 })
+  }
+  try {
+    const ticket = await prisma.serviceTicket.update({
+      where: { id: params.id },
+      data: { status: TicketStatus.CLOSED, resolution: parsed.data.resolution },
+      include: { customer: true, item: true, assignedTo: true }
+    })
+    return NextResponse.json(ticket)
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  }
+}
+

--- a/app/api/services/route.ts
+++ b/app/api/services/route.ts
@@ -1,0 +1,35 @@
+import { prisma } from '@/lib/prisma'
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+const createSchema = z.object({
+  customerId: z.string().min(1),
+  itemId: z.string().min(1),
+  description: z.string().optional()
+})
+
+export async function GET() {
+  const tickets = await prisma.serviceTicket.findMany({
+    include: { customer: true, item: true, assignedTo: true },
+    orderBy: { createdAt: 'desc' }
+  })
+  return NextResponse.json(tickets)
+}
+
+export async function POST(req: Request) {
+  const data = await req.json()
+  const parsed = createSchema.safeParse(data)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.format() }, { status: 400 })
+  }
+  try {
+    const ticket = await prisma.serviceTicket.create({
+      data: parsed.data,
+      include: { customer: true, item: true }
+    })
+    return NextResponse.json(ticket)
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  }
+}
+

--- a/app/services/[id]/assign/page.tsx
+++ b/app/services/[id]/assign/page.tsx
@@ -1,0 +1,23 @@
+import AssignTicketForm from '@/AssignTicketForm'
+import { prisma } from '@/lib/prisma'
+
+interface Params { params: { id: string } }
+
+async function loadUsers() {
+  try {
+    return await prisma.user.findMany({ select: { id: true, name: true }, orderBy: { name: 'asc' } })
+  } catch {
+    return []
+  }
+}
+
+export default async function Page({ params }: Params) {
+  const users = await loadUsers()
+  return (
+    <div>
+      <h1 className="text-xl font-bold mb-4">Assign Ticket</h1>
+      <AssignTicketForm ticketId={params.id} users={users} />
+    </div>
+  )
+}
+

--- a/app/services/[id]/close/page.tsx
+++ b/app/services/[id]/close/page.tsx
@@ -1,0 +1,13 @@
+import CloseTicketForm from '@/CloseTicketForm'
+
+interface Params { params: { id: string } }
+
+export default function Page({ params }: Params) {
+  return (
+    <div>
+      <h1 className="text-xl font-bold mb-4">Close Ticket</h1>
+      <CloseTicketForm ticketId={params.id} />
+    </div>
+  )
+}
+

--- a/app/services/new/page.tsx
+++ b/app/services/new/page.tsx
@@ -1,0 +1,23 @@
+import NewTicketForm from '@/NewTicketForm'
+import { prisma } from '@/lib/prisma'
+
+async function loadData() {
+  try {
+    const customers = await prisma.customer.findMany({ orderBy: { name: 'asc' }, select: { id: true, name: true } })
+    const items = await prisma.item.findMany({ orderBy: { name: 'asc' }, select: { id: true, name: true } })
+    return { customers, items }
+  } catch {
+    return { customers: [], items: [] }
+  }
+}
+
+export default async function Page() {
+  const data = await loadData()
+  return (
+    <div>
+      <h1 className="text-xl font-bold mb-4">New Service Ticket</h1>
+      <NewTicketForm customers={data.customers} items={data.items} />
+    </div>
+  )
+}
+

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -1,8 +1,55 @@
-export default function Page() {
+import Link from 'next/link'
+import { prisma } from '@/lib/prisma'
+
+async function loadTickets() {
+  try {
+    return await prisma.serviceTicket.findMany({
+      include: { customer: true, item: true, assignedTo: true },
+      orderBy: { createdAt: 'desc' }
+    })
+  } catch {
+    return []
+  }
+}
+
+export default async function Page() {
+  const tickets = await loadTickets()
   return (
     <div>
-      <h1 className="text-xl font-bold mb-4">Services Module</h1>
-      <p>Placeholder page for the Services module.</p>
+      <h1 className="text-xl font-bold mb-4">Service Tickets</h1>
+      <div className="mb-4">
+        <Link href="/services/new" className="btn">New Ticket</Link>
+      </div>
+      <table className="table">
+        <thead>
+          <tr>
+            <th className="th">Customer</th>
+            <th className="th">Item</th>
+            <th className="th">Status</th>
+            <th className="th">Assigned To</th>
+            <th className="th">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {tickets.map(t => (
+            <tr key={t.id} className="hover:bg-gray-50">
+              <td className="td">{t.customer.name}</td>
+              <td className="td">{t.item.name}</td>
+              <td className="td"><span className="badge">{t.status}</span></td>
+              <td className="td">{t.assignedTo?.name || '-'}</td>
+              <td className="td space-x-2">
+                {t.status === 'NEW' && (
+                  <Link href={`/services/${t.id}/assign`} className="btn">Assign</Link>
+                )}
+                {t.status !== 'CLOSED' && (
+                  <Link href={`/services/${t.id}/close`} className="btn">Close</Link>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   )
 }
+

--- a/schema.prisma
+++ b/schema.prisma
@@ -17,6 +17,7 @@ model User {
   updatedAt    DateTime @updatedAt
 
   sessions Session[]
+  assignedTickets ServiceTicket[]
 }
 
 model Session {
@@ -59,6 +60,7 @@ model Customer {
   createdAt   DateTime     @default(now())
   updatedAt   DateTime     @updatedAt
   orders      SalesOrder[]
+  serviceTickets ServiceTicket[]
 }
 
 model Warehouse {
@@ -102,6 +104,7 @@ model Item {
   formulations Formulation[]
   batches      ProductionBatch[]
   salesLines   SalesOrderLine[]
+  serviceTickets ServiceTicket[]
 }
 
 enum ItemCategory {
@@ -256,4 +259,25 @@ model COA {
   lot       InventoryLot @relation(fields: [lotId], references: [id], onDelete: Cascade)
   url       String? // link to PDF stored elsewhere
   createdAt DateTime     @default(now())
+}
+
+model ServiceTicket {
+  id           String        @id @default(cuid())
+  customerId   String
+  customer     Customer      @relation(fields: [customerId], references: [id], onDelete: Cascade)
+  itemId       String
+  item         Item          @relation(fields: [itemId], references: [id])
+  description  String?
+  status       TicketStatus  @default(NEW)
+  assignedToId String?
+  assignedTo   User?         @relation(fields: [assignedToId], references: [id])
+  resolution   String?
+  createdAt    DateTime      @default(now())
+  updatedAt    DateTime      @updatedAt
+}
+
+enum TicketStatus {
+  NEW
+  ASSIGNED
+  CLOSED
 }


### PR DESCRIPTION
## Summary
- add `ServiceTicket` model with status enum and relations to customer, item, and assignee
- implement service ticket APIs for creation, assignment, and closure
- build pages and forms to create, assign, and close service tickets

## Testing
- `npx prisma generate`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1c81705e08328b9498aa2a2b80904