### PR TITLE
Add point-of-sale models, API route, and touchscreen interface

### DIFF
--- a/app/api/pos/route.ts
+++ b/app/api/pos/route.ts
@@ -1,0 +1,63 @@
+import { prisma } from '@/lib/prisma'
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+const lineSchema = z.object({
+  itemId: z.string().min(1),
+  qty: z.number().positive(),
+  unitPrice: z.number().nonnegative()
+})
+
+const schema = z.object({
+  orderNo: z.string().min(1),
+  lines: z.array(lineSchema).min(1)
+})
+
+export async function GET() {
+  const orders = await prisma.pOSOrder.findMany({
+    include: { lines: { include: { item: true } }, entries: true },
+    orderBy: { createdAt: 'desc' }
+  })
+  return NextResponse.json(orders)
+}
+
+export async function POST(req: Request) {
+  const data = await req.json()
+  const parsed = schema.safeParse(data)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.format() }, { status: 400 })
+  const total = parsed.data.lines.reduce((sum, l) => sum + l.qty * l.unitPrice, 0)
+  try {
+    const order = await prisma.$transaction(async tx => {
+      const created = await tx.pOSOrder.create({
+        data: {
+          orderNo: parsed.data.orderNo,
+          total,
+          lines: {
+            create: parsed.data.lines.map(l => ({ itemId: l.itemId, qty: l.qty, unitPrice: l.unitPrice }))
+          }
+        },
+        include: { lines: true }
+      })
+
+      for (const line of created.lines) {
+        const lot = await tx.inventoryLot.findFirst({ where: { itemId: line.itemId }, orderBy: { createdAt: 'asc' } })
+        if (lot) {
+          await tx.inventoryLot.update({ where: { id: lot.id }, data: { qty: { decrement: line.qty } } })
+        }
+      }
+
+      await tx.accountingEntry.createMany({
+        data: [
+          { posOrderId: created.id, account: 'Cash', debit: total },
+          { posOrderId: created.id, account: 'Sales', credit: total }
+        ]
+      })
+
+      return created
+    })
+
+    return NextResponse.json(order)
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  }
+}

--- a/app/pos/page.tsx
+++ b/app/pos/page.tsx
@@ -1,8 +1,112 @@
+'use client'
+
+import axios from 'axios'
+import { useEffect, useState } from 'react'
+
+interface Item {
+  id: string
+  name: string
+}
+
+interface CartLine {
+  item: Item
+  qty: number
+  unitPrice: number
+}
+
 export default function Page() {
+  const [items, setItems] = useState<Item[]>([])
+  const [cart, setCart] = useState<CartLine[]>([])
+
+  useEffect(() => {
+    axios.get('/api/items').then(res => setItems(res.data))
+  }, [])
+
+  function addToCart(item: Item) {
+    setCart(prev => {
+      const existing = prev.find(l => l.item.id === item.id)
+      if (existing) {
+        return prev.map(l => (l.item.id === item.id ? { ...l, qty: l.qty + 1 } : l))
+      }
+      return [...prev, { item, qty: 1, unitPrice: 0 }]
+    })
+  }
+
+  function updateQty(id: string, delta: number) {
+    setCart(prev =>
+      prev.map(l =>
+        l.item.id === id ? { ...l, qty: Math.max(1, l.qty + delta) } : l
+      )
+    )
+  }
+
+  function updatePrice(id: string, price: number) {
+    setCart(prev => prev.map(l => (l.item.id === id ? { ...l, unitPrice: price } : l)))
+  }
+
+  async function checkout() {
+    const payload = {
+      orderNo: `POS-${Date.now()}`,
+      lines: cart.map(l => ({ itemId: l.item.id, qty: l.qty, unitPrice: l.unitPrice }))
+    }
+    await axios.post('/api/pos', payload)
+    setCart([])
+  }
+
+  const total = cart.reduce((sum, l) => sum + l.qty * l.unitPrice, 0)
+
   return (
-    <div>
-      <h1 className="text-xl font-bold mb-4">Pos Module</h1>
-      <p>Placeholder page for the Pos module.</p>
+    <div className="flex flex-col md:flex-row gap-4">
+      <div className="flex-1">
+        <h1 className="text-xl font-bold mb-4">Point of Sale</h1>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {items.map(it => (
+            <button
+              key={it.id}
+              onClick={() => addToCart(it)}
+              className="p-4 bg-blue-500 text-white rounded-lg text-xl"
+            >
+              {it.name}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="w-full md:w-1/3">
+        <h2 className="text-lg font-semibold mb-2">Cart</h2>
+        {cart.map(line => (
+          <div key={line.item.id} className="flex items-center mb-2">
+            <div className="flex-1">{line.item.name}</div>
+            <div className="flex items-center">
+              <button
+                className="px-2 py-1 bg-gray-300"
+                onClick={() => updateQty(line.item.id, -1)}
+              >
+                -
+              </button>
+              <span className="px-2">{line.qty}</span>
+              <button
+                className="px-2 py-1 bg-gray-300"
+                onClick={() => updateQty(line.item.id, 1)}
+              >
+                +
+              </button>
+            </div>
+            <input
+              type="number"
+              className="w-20 ml-2 border p-1"
+              value={line.unitPrice}
+              onChange={e => updatePrice(line.item.id, parseFloat(e.target.value) || 0)}
+            />
+          </div>
+        ))}
+        <div className="font-bold mt-4">Total: {total.toFixed(2)}</div>
+        <button
+          onClick={checkout}
+          className="mt-4 w-full p-4 bg-green-500 text-white rounded-lg text-xl"
+        >
+          Checkout
+        </button>
+      </div>
     </div>
   )
 }

--- a/schema.prisma
+++ b/schema.prisma
@@ -102,6 +102,7 @@ model Item {
   formulations Formulation[]
   batches      ProductionBatch[]
   salesLines   SalesOrderLine[]
+  posLines     POSOrderLine[]
 }
 
 enum ItemCategory {
@@ -257,3 +258,33 @@ model COA {
   url       String? // link to PDF stored elsewhere
   createdAt DateTime     @default(now())
 }
+
+model POSOrder {
+  id        String          @id @default(cuid())
+  orderNo   String          @unique
+  total     Float
+  createdAt DateTime        @default(now())
+  lines     POSOrderLine[]
+  entries   AccountingEntry[]
+}
+
+model POSOrderLine {
+  id        String    @id @default(cuid())
+  orderId   String
+  order     POSOrder  @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  itemId    String
+  item      Item      @relation(fields: [itemId], references: [id])
+  qty       Float
+  unitPrice Float
+}
+
+model AccountingEntry {
+  id        String   @id @default(cuid())
+  posOrderId String
+  posOrder  POSOrder @relation(fields: [posOrderId], references: [id], onDelete: Cascade)
+  account   String
+  debit     Float    @default(0)
+  credit    Float    @default(0)
+  createdAt DateTime @default(now())
+}
+


### PR DESCRIPTION
## Summary
- extend Prisma schema with POSOrder, POSOrderLine, and AccountingEntry models
- create `/api/pos` endpoint to record sales, deduct inventory, and post accounting entries
- build touchscreen-friendly `/pos` page for quick item selection and checkout

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1c813f4c083288dedfb4057ac33a8