### PR TITLE
feat: add CRM pipeline with leads and opportunities

### DIFF
--- a/ConvertLeadButton.tsx
+++ b/ConvertLeadButton.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import axios from 'axios'
+import { useState } from 'react'
+
+export default function ConvertLeadButton({ id }: { id: string }) {
+  const [loading, setLoading] = useState(false)
+
+  async function convert() {
+    setLoading(true)
+    try {
+      await axios.post(`/api/crm/leads/${id}/convert`)
+      window.location.reload()
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <button className="btn" onClick={convert} disabled={loading}>
+      {loading ? 'Converting...' : 'Convert'}
+    </button>
+  )
+}

--- a/InteractionForm.tsx
+++ b/InteractionForm.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { useState } from 'react'
+import axios from 'axios'
+import { InteractionType } from '@prisma/client'
+
+export default function InteractionForm({ leadId }: { leadId: string }) {
+  const [form, setForm] = useState<{ type: InteractionType; note: string }>({ type: InteractionType.NOTE, note: '' })
+  const [loading, setLoading] = useState(false)
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    setLoading(true)
+    await axios.post('/api/crm/interactions', { leadId, type: form.type, note: form.note })
+    setForm({ type: InteractionType.NOTE, note: '' })
+    setLoading(false)
+    window.location.reload()
+  }
+
+  return (
+    <form onSubmit={submit} className="flex space-x-2 mt-2">
+      <select className="input w-32" value={form.type} onChange={e=>setForm({ ...form, type: e.target.value as InteractionType })}>
+        {Object.values(InteractionType).map(t => (
+          <option key={t} value={t}>{t}</option>
+        ))}
+      </select>
+      <input className="input flex-1" value={form.note} onChange={e=>setForm({ ...form, note: e.target.value })} placeholder="Note" />
+      <button className="btn" disabled={loading}>{loading ? 'Add...' : 'Add'}</button>
+    </form>
+  )
+}

--- a/LeadForm.tsx
+++ b/LeadForm.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { useState } from 'react'
+import axios from 'axios'
+
+export default function LeadForm() {
+  const [form, setForm] = useState({ name: '', email: '', phone: '' })
+  const [loading, setLoading] = useState(false)
+  const [msg, setMsg] = useState<string | null>(null)
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    setLoading(true); setMsg(null)
+    try {
+      await axios.post('/api/crm/leads', form)
+      setForm({ name: '', email: '', phone: '' })
+      setMsg('Created')
+      window.location.reload()
+    } catch {
+      setMsg('Failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <form onSubmit={submit} className="space-y-3">
+      <div>
+        <label className="label">Name</label>
+        <input className="input" value={form.name} onChange={e => setForm({ ...form, name: e.target.value })} required />
+      </div>
+      <div>
+        <label className="label">Email</label>
+        <input className="input" value={form.email} onChange={e => setForm({ ...form, email: e.target.value })} />
+      </div>
+      <div>
+        <label className="label">Phone</label>
+        <input className="input" value={form.phone} onChange={e => setForm({ ...form, phone: e.target.value })} />
+      </div>
+      <button className="btn" disabled={loading}>{loading ? 'Saving...' : 'Save Lead'}</button>
+      {msg && <div className="text-sm text-gray-500">{msg}</div>}
+    </form>
+  )
+}

--- a/OpportunityForm.tsx
+++ b/OpportunityForm.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { useState } from 'react'
+import axios from 'axios'
+
+export default function OpportunityForm({ leads }: { leads: { id: string; name: string }[] }) {
+  const [form, setForm] = useState({ title: '', value: '', leadId: '' })
+  const [loading, setLoading] = useState(false)
+  const [msg, setMsg] = useState<string | null>(null)
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    setLoading(true); setMsg(null)
+    try {
+      await axios.post('/api/crm/opportunities', { title: form.title, value: form.value ? Number(form.value) : undefined, leadId: form.leadId || undefined })
+      setForm({ title: '', value: '', leadId: '' })
+      setMsg('Created')
+      window.location.reload()
+    } catch {
+      setMsg('Failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <form onSubmit={submit} className="space-y-3">
+      <div>
+        <label className="label">Title</label>
+        <input className="input" value={form.title} onChange={e => setForm({ ...form, title: e.target.value })} required />
+      </div>
+      <div>
+        <label className="label">Value</label>
+        <input type="number" className="input" value={form.value} onChange={e => setForm({ ...form, value: e.target.value })} />
+      </div>
+      <div>
+        <label className="label">Lead</label>
+        <select className="input" value={form.leadId} onChange={e => setForm({ ...form, leadId: e.target.value })}>
+          <option value="">None</option>
+          {leads.map(l => (
+            <option key={l.id} value={l.id}>{l.name}</option>
+          ))}
+        </select>
+      </div>
+      <button className="btn" disabled={loading}>{loading ? 'Saving...' : 'Save Opportunity'}</button>
+      {msg && <div className="text-sm text-gray-500">{msg}</div>}
+    </form>
+  )
+}

--- a/app/api/crm/interactions/route.ts
+++ b/app/api/crm/interactions/route.ts
@@ -1,0 +1,36 @@
+import { prisma } from '@/lib/prisma'
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { InteractionType } from '@prisma/client'
+
+const schema = z.object({
+  leadId: z.string().optional(),
+  opportunityId: z.string().optional(),
+  customerId: z.string().optional(),
+  type: z.nativeEnum(InteractionType),
+  note: z.string().optional()
+}).refine(data => data.leadId || data.opportunityId || data.customerId, {
+  message: 'leadId, opportunityId or customerId required'
+})
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const where: any = {}
+  if (searchParams.get('leadId')) where.leadId = searchParams.get('leadId')
+  if (searchParams.get('opportunityId')) where.opportunityId = searchParams.get('opportunityId')
+  if (searchParams.get('customerId')) where.customerId = searchParams.get('customerId')
+  const interactions = await prisma.interaction.findMany({ where, orderBy: { createdAt: 'desc' } })
+  return NextResponse.json(interactions)
+}
+
+export async function POST(req: Request) {
+  const data = await req.json()
+  const parsed = schema.safeParse(data)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.format() }, { status: 400 })
+  try {
+    const interaction = await prisma.interaction.create({ data: parsed.data })
+    return NextResponse.json(interaction)
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  }
+}

--- a/app/api/crm/leads/[id]/convert/route.ts
+++ b/app/api/crm/leads/[id]/convert/route.ts
@@ -1,0 +1,20 @@
+import { prisma } from '@/lib/prisma'
+import { NextResponse } from 'next/server'
+
+export async function POST(req: Request, { params }: { params: { id: string } }) {
+  try {
+    const lead = await prisma.lead.findUnique({ where: { id: params.id } })
+    if (!lead) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+    if (lead.customerId) {
+      const customer = await prisma.customer.findUnique({ where: { id: lead.customerId } })
+      return NextResponse.json(customer)
+    }
+    const customer = await prisma.customer.create({
+      data: { name: lead.name, email: lead.email, phone: lead.phone }
+    })
+    await prisma.lead.update({ where: { id: lead.id }, data: { status: 'CONVERTED', customerId: customer.id } })
+    return NextResponse.json(customer)
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  }
+}

--- a/app/api/crm/leads/route.ts
+++ b/app/api/crm/leads/route.ts
@@ -1,0 +1,28 @@
+import { prisma } from '@/lib/prisma'
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { LeadStatus } from '@prisma/client'
+
+const schema = z.object({
+  name: z.string().min(1),
+  email: z.string().email().optional().or(z.literal('')),
+  phone: z.string().optional().or(z.literal('')),
+  status: z.nativeEnum(LeadStatus).optional()
+})
+
+export async function GET() {
+  const leads = await prisma.lead.findMany({ orderBy: { createdAt: 'desc' }, include: { interactions: true } })
+  return NextResponse.json(leads)
+}
+
+export async function POST(req: Request) {
+  const data = await req.json()
+  const parsed = schema.safeParse(data)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.format() }, { status: 400 })
+  try {
+    const lead = await prisma.lead.create({ data: { ...parsed.data, email: parsed.data.email || null, phone: parsed.data.phone || null } })
+    return NextResponse.json(lead)
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  }
+}

--- a/app/api/crm/opportunities/route.ts
+++ b/app/api/crm/opportunities/route.ts
@@ -1,0 +1,29 @@
+import { prisma } from '@/lib/prisma'
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { OpportunityStage } from '@prisma/client'
+
+const schema = z.object({
+  title: z.string().min(1),
+  value: z.number().optional(),
+  stage: z.nativeEnum(OpportunityStage).optional(),
+  leadId: z.string().optional(),
+  customerId: z.string().optional()
+})
+
+export async function GET() {
+  const ops = await prisma.opportunity.findMany({ orderBy: { createdAt: 'desc' } })
+  return NextResponse.json(ops)
+}
+
+export async function POST(req: Request) {
+  const data = await req.json()
+  const parsed = schema.safeParse(data)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.format() }, { status: 400 })
+  try {
+    const op = await prisma.opportunity.create({ data: parsed.data })
+    return NextResponse.json(op)
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  }
+}

--- a/app/crm/page.tsx
+++ b/app/crm/page.tsx
@@ -1,8 +1,64 @@
-export default function Page() {
+import LeadForm from '@/LeadForm'
+import OpportunityForm from '@/OpportunityForm'
+import InteractionForm from '@/InteractionForm'
+import ConvertLeadButton from '@/ConvertLeadButton'
+import { prisma } from '@/lib/prisma'
+
+async function loadLeads() {
+  try {
+    return await prisma.lead.findMany({ orderBy: { createdAt: 'desc' }, include: { interactions: true } })
+  } catch {
+    return []
+  }
+}
+
+async function loadOpportunities() {
+  try {
+    return await prisma.opportunity.findMany({ orderBy: { createdAt: 'desc' } })
+  } catch {
+    return []
+  }
+}
+
+export default async function Page() {
+  const [leads, opportunities] = await Promise.all([loadLeads(), loadOpportunities()])
   return (
     <div>
-      <h1 className="text-xl font-bold mb-4">Crm Module</h1>
-      <p>Placeholder page for the Crm module.</p>
+      <h1 className="text-xl font-bold mb-4">CRM</h1>
+      <div className="mb-8">
+        <LeadForm />
+      </div>
+      <h2 className="text-lg font-semibold mb-2">Leads</h2>
+      <div className="space-y-4">
+        {leads.map((lead: any) => (
+          <div key={lead.id} className="border p-3 rounded">
+            <div className="flex justify-between items-center">
+              <div>
+                <div className="font-medium">{lead.name}</div>
+                <div className="text-sm text-gray-500">{lead.status}</div>
+              </div>
+              {lead.status !== 'CONVERTED' && <ConvertLeadButton id={lead.id} />}
+            </div>
+            <div className="mt-2 ml-2">
+              <ul className="text-sm list-disc list-inside">
+                {lead.interactions.map((i: any) => (
+                  <li key={i.id}>{i.type}: {i.note}</li>
+                ))}
+              </ul>
+              <InteractionForm leadId={lead.id} />
+            </div>
+          </div>
+        ))}
+      </div>
+      <h2 className="text-lg font-semibold mt-8 mb-2">Opportunities</h2>
+      <div className="mb-4">
+        <OpportunityForm leads={leads} />
+      </div>
+      <ul className="space-y-1">
+        {opportunities.map((op: any) => (
+          <li key={op.id} className="border p-2 rounded">{op.title} - {op.stage} - {op.value ?? 0}</li>
+        ))}
+      </ul>
     </div>
   )
 }

--- a/schema.prisma
+++ b/schema.prisma
@@ -59,6 +59,9 @@ model Customer {
   createdAt   DateTime     @default(now())
   updatedAt   DateTime     @updatedAt
   orders      SalesOrder[]
+  leads       Lead[]
+  opportunities Opportunity[]
+  interactions  Interaction[]
 }
 
 model Warehouse {
@@ -257,3 +260,68 @@ model COA {
   url       String? // link to PDF stored elsewhere
   createdAt DateTime     @default(now())
 }
+
+enum LeadStatus {
+  NEW
+  CONTACTED
+  QUALIFIED
+  CONVERTED
+  LOST
+}
+
+enum OpportunityStage {
+  QUALIFICATION
+  PROPOSAL
+  NEGOTIATION
+  WON
+  LOST
+}
+
+enum InteractionType {
+  CALL
+  EMAIL
+  MEETING
+  NOTE
+}
+
+model Lead {
+  id          String        @id @default(cuid())
+  name        String
+  email       String?
+  phone       String?
+  status      LeadStatus     @default(NEW)
+  customerId  String?
+  customer    Customer?     @relation(fields: [customerId], references: [id])
+  createdAt   DateTime       @default(now())
+  updatedAt   DateTime       @updatedAt
+  opportunities Opportunity[]
+  interactions  Interaction[]
+}
+
+model Opportunity {
+  id          String           @id @default(cuid())
+  title       String
+  value       Float?
+  stage       OpportunityStage @default(QUALIFICATION)
+  leadId      String?
+  lead        Lead?            @relation(fields: [leadId], references: [id], onDelete: Cascade)
+  customerId  String?
+  customer    Customer?        @relation(fields: [customerId], references: [id])
+  createdAt   DateTime         @default(now())
+  updatedAt   DateTime         @updatedAt
+  interactions Interaction[]
+}
+
+model Interaction {
+  id            String        @id @default(cuid())
+  leadId        String?
+  lead          Lead?         @relation(fields: [leadId], references: [id], onDelete: Cascade)
+  opportunityId String?
+  opportunity   Opportunity?  @relation(fields: [opportunityId], references: [id], onDelete: Cascade)
+  customerId    String?
+  customer      Customer?     @relation(fields: [customerId], references: [id])
+  type          InteractionType
+  note          String?
+  createdAt     DateTime       @default(now())
+}
+


### PR DESCRIPTION
## Summary
- define Lead, Opportunity and Interaction models
- expose CRM API routes for leads, opportunities and interactions
- build CRM page with lead tracking, interactions and conversion to customers

## Testing
- `npx tsc --noEmit`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1c8112db48328bc3fe081db9f49d2