### PR TITLE
Add employee management module

### DIFF
--- a/EmployeeForm.tsx
+++ b/EmployeeForm.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { useState } from 'react'
+import axios from 'axios'
+
+export default function EmployeeForm() {
+  const [form, setForm] = useState({ firstName: '', lastName: '', email: '', phone: '', department: '', role: '', userEmail: '' })
+  const [loading, setLoading] = useState(false)
+  const [msg, setMsg] = useState<string | null>(null)
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    setLoading(true); setMsg(null)
+    const res = await axios.post('/api/hr/employees', form)
+    setLoading(false)
+    if (res.status === 200) {
+      setMsg('Created')
+      setForm({ firstName: '', lastName: '', email: '', phone: '', department: '', role: '', userEmail: '' })
+      window.location.reload()
+    } else setMsg('Failed')
+  }
+
+  return (
+    <form onSubmit={submit} className="space-y-3">
+      <div>
+        <label className="label">First Name</label>
+        <input className="input" value={form.firstName} onChange={e => setForm({ ...form, firstName: e.target.value })} required />
+      </div>
+      <div>
+        <label className="label">Last Name</label>
+        <input className="input" value={form.lastName} onChange={e => setForm({ ...form, lastName: e.target.value })} required />
+      </div>
+      <div>
+        <label className="label">Email</label>
+        <input className="input" value={form.email} onChange={e => setForm({ ...form, email: e.target.value })} />
+      </div>
+      <div>
+        <label className="label">Phone</label>
+        <input className="input" value={form.phone} onChange={e => setForm({ ...form, phone: e.target.value })} />
+      </div>
+      <div>
+        <label className="label">Department</label>
+        <input className="input" value={form.department} onChange={e => setForm({ ...form, department: e.target.value })} />
+      </div>
+      <div>
+        <label className="label">Role</label>
+        <input className="input" value={form.role} onChange={e => setForm({ ...form, role: e.target.value })} />
+      </div>
+      <div>
+        <label className="label">User Email</label>
+        <input className="input" value={form.userEmail} onChange={e => setForm({ ...form, userEmail: e.target.value })} />
+      </div>
+      <button className="btn" disabled={loading}>{loading ? 'Saving...' : 'Save Employee'}</button>
+      {msg && <div className="text-sm text-gray-500">{msg}</div>}
+    </form>
+  )
+}

--- a/EmployeeProfileForm.tsx
+++ b/EmployeeProfileForm.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { useState } from 'react'
+import axios from 'axios'
+import { Employee, Department, JobRole, User } from '@prisma/client'
+
+type Emp = Employee & { department: Department | null, role: JobRole | null, user: User | null }
+
+export default function EmployeeProfileForm({ employee }: { employee: Emp }) {
+  const [form, setForm] = useState({
+    firstName: employee.firstName,
+    lastName: employee.lastName,
+    email: employee.email || '',
+    phone: employee.phone || '',
+    department: employee.department?.name || '',
+    role: employee.role?.name || '',
+    userEmail: employee.user?.email || ''
+  })
+  const [loading, setLoading] = useState(false)
+  const [msg, setMsg] = useState<string | null>(null)
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    setLoading(true); setMsg(null)
+    const res = await axios.put(`/api/hr/employees/${employee.id}`, form)
+    setLoading(false)
+    if (res.status === 200) setMsg('Saved')
+    else setMsg('Failed')
+  }
+
+  return (
+    <form onSubmit={submit} className="space-y-3">
+      <div>
+        <label className="label">First Name</label>
+        <input className="input" value={form.firstName} onChange={e => setForm({ ...form, firstName: e.target.value })} required />
+      </div>
+      <div>
+        <label className="label">Last Name</label>
+        <input className="input" value={form.lastName} onChange={e => setForm({ ...form, lastName: e.target.value })} required />
+      </div>
+      <div>
+        <label className="label">Email</label>
+        <input className="input" value={form.email} onChange={e => setForm({ ...form, email: e.target.value })} />
+      </div>
+      <div>
+        <label className="label">Phone</label>
+        <input className="input" value={form.phone} onChange={e => setForm({ ...form, phone: e.target.value })} />
+      </div>
+      <div>
+        <label className="label">Department</label>
+        <input className="input" value={form.department} onChange={e => setForm({ ...form, department: e.target.value })} />
+      </div>
+      <div>
+        <label className="label">Role</label>
+        <input className="input" value={form.role} onChange={e => setForm({ ...form, role: e.target.value })} />
+      </div>
+      <div>
+        <label className="label">User Email</label>
+        <input className="input" value={form.userEmail} onChange={e => setForm({ ...form, userEmail: e.target.value })} />
+      </div>
+      <button className="btn" disabled={loading}>{loading ? 'Saving...' : 'Save'}</button>
+      {msg && <div className="text-sm text-gray-500">{msg}</div>}
+    </form>
+  )
+}

--- a/EmployeeTable.tsx
+++ b/EmployeeTable.tsx
@@ -1,0 +1,32 @@
+'use client'
+import Link from 'next/link'
+import { Employee, Department, JobRole, User } from '@prisma/client'
+
+type Emp = Employee & { department: Department | null, role: JobRole | null, user: User | null }
+
+export default function EmployeeTable({ employees }: { employees: Emp[] }) {
+  return (
+    <table className="table">
+      <thead>
+        <tr>
+          <th className="th">Name</th>
+          <th className="th">Department</th>
+          <th className="th">Role</th>
+          <th className="th">Email</th>
+          <th className="th">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {employees.map(e => (
+          <tr key={e.id} className="hover:bg-gray-50">
+            <td className="td">{e.firstName} {e.lastName}</td>
+            <td className="td">{e.department?.name || ''}</td>
+            <td className="td">{e.role?.name || ''}</td>
+            <td className="td">{e.email || ''}</td>
+            <td className="td"><Link href={`/hr/${e.id}`} className="link">Edit</Link></td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}

--- a/app/api/hr/employees/[id]/route.ts
+++ b/app/api/hr/employees/[id]/route.ts
@@ -1,0 +1,77 @@
+import { prisma } from '@/lib/prisma'
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+const schema = z.object({
+  firstName: z.string().min(1).optional(),
+  lastName: z.string().min(1).optional(),
+  email: z.string().email().optional().or(z.literal('')),
+  phone: z.string().optional().or(z.literal('')),
+  department: z.string().optional().or(z.literal('')),
+  role: z.string().optional().or(z.literal('')),
+  userEmail: z.string().email().optional().or(z.literal(''))
+})
+
+export async function GET(req: Request, { params }: { params: { id: string } }) {
+  const employee = await prisma.employee.findUnique({
+    where: { id: params.id },
+    include: { department: true, role: true, user: true }
+  })
+  if (!employee) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  return NextResponse.json(employee)
+}
+
+export async function PUT(req: Request, { params }: { params: { id: string } }) {
+  const data = await req.json()
+  const parsed = schema.safeParse(data)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.format() }, { status: 400 })
+  try {
+    const { department, role, userEmail, ...rest } = parsed.data
+    let deptAction: any = undefined
+    if (department !== undefined) {
+      if (department === '') deptAction = { disconnect: true }
+      else {
+        const dept = await prisma.department.upsert({ where: { name: department }, create: { name: department }, update: {} })
+        deptAction = { connect: { id: dept.id } }
+      }
+    }
+    let roleAction: any = undefined
+    if (role !== undefined) {
+      if (role === '') roleAction = { disconnect: true }
+      else {
+        const r = await prisma.jobRole.upsert({ where: { name: role }, create: { name: role }, update: {} })
+        roleAction = { connect: { id: r.id } }
+      }
+    }
+    let userAction: any = undefined
+    if (userEmail !== undefined) {
+      if (userEmail === '') userAction = { disconnect: true }
+      else {
+        const u = await prisma.user.findUnique({ where: { email: userEmail } })
+        if (u) userAction = { connect: { id: u.id } }
+      }
+    }
+    const employee = await prisma.employee.update({
+      where: { id: params.id },
+      data: {
+        ...rest,
+        ...(deptAction ? { department: deptAction } : {}),
+        ...(roleAction ? { role: roleAction } : {}),
+        ...(userAction ? { user: userAction } : {})
+      },
+      include: { department: true, role: true, user: true }
+    })
+    return NextResponse.json(employee)
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  }
+}
+
+export async function DELETE(req: Request, { params }: { params: { id: string } }) {
+  try {
+    await prisma.employee.delete({ where: { id: params.id } })
+    return NextResponse.json({ ok: true })
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  }
+}

--- a/app/api/hr/employees/route.ts
+++ b/app/api/hr/employees/route.ts
@@ -1,0 +1,60 @@
+import { prisma } from '@/lib/prisma'
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+const schema = z.object({
+  firstName: z.string().min(1),
+  lastName: z.string().min(1),
+  email: z.string().email().optional().or(z.literal('')),
+  phone: z.string().optional().or(z.literal('')),
+  department: z.string().optional().or(z.literal('')),
+  role: z.string().optional().or(z.literal('')),
+  userEmail: z.string().email().optional().or(z.literal(''))
+})
+
+export async function GET() {
+  const employees = await prisma.employee.findMany({
+    include: { department: true, role: true, user: true },
+    orderBy: { createdAt: 'desc' }
+  })
+  return NextResponse.json(employees)
+}
+
+export async function POST(req: Request) {
+  const data = await req.json()
+  const parsed = schema.safeParse(data)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.format() }, { status: 400 })
+  try {
+    const { department, role, userEmail, ...rest } = parsed.data
+    let deptConnect: any = undefined
+    if (department) {
+      const dept = await prisma.department.upsert({ where: { name: department }, create: { name: department }, update: {} })
+      deptConnect = { connect: { id: dept.id } }
+    }
+    let roleConnect: any = undefined
+    if (role) {
+      const r = await prisma.jobRole.upsert({ where: { name: role }, create: { name: role }, update: {} })
+      roleConnect = { connect: { id: r.id } }
+    }
+    let userConnect: any = undefined
+    if (userEmail) {
+      const u = await prisma.user.findUnique({ where: { email: userEmail } })
+      if (u) userConnect = { connect: { id: u.id } }
+    }
+    const employee = await prisma.employee.create({
+      data: {
+        firstName: rest.firstName,
+        lastName: rest.lastName,
+        email: rest.email || null,
+        phone: rest.phone || null,
+        ...(deptConnect ? { department: deptConnect } : {}),
+        ...(roleConnect ? { role: roleConnect } : {}),
+        ...(userConnect ? { user: userConnect } : {})
+      },
+      include: { department: true, role: true, user: true }
+    })
+    return NextResponse.json(employee)
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  }
+}

--- a/app/hr/[id]/page.tsx
+++ b/app/hr/[id]/page.tsx
@@ -1,0 +1,16 @@
+import EmployeeProfileForm from '@/EmployeeProfileForm'
+import { prisma } from '@/lib/prisma'
+
+export default async function Page({ params }: { params: { id: string } }) {
+  const employee = await prisma.employee.findUnique({
+    where: { id: params.id },
+    include: { department: true, role: true, user: true }
+  })
+  if (!employee) return <div>Not found</div>
+  return (
+    <div>
+      <h1 className="text-xl font-bold mb-4">Employee Profile</h1>
+      <EmployeeProfileForm employee={employee} />
+    </div>
+  )
+}

--- a/app/hr/page.tsx
+++ b/app/hr/page.tsx
@@ -1,8 +1,24 @@
-export default function Page() {
+import EmployeeTable from '@/EmployeeTable'
+import EmployeeForm from '@/EmployeeForm'
+import { prisma } from '@/lib/prisma'
+
+async function loadEmployees() {
+  try {
+    return await prisma.employee.findMany({ include: { department: true, role: true, user: true }, orderBy: { createdAt: 'desc' } })
+  } catch {
+    return []
+  }
+}
+
+export default async function Page() {
+  const employees = await loadEmployees()
   return (
     <div>
-      <h1 className="text-xl font-bold mb-4">Hr Module</h1>
-      <p>Placeholder page for the Hr module.</p>
+      <h1 className="text-xl font-bold mb-4">Employees</h1>
+      <div className="mb-8">
+        <EmployeeForm />
+      </div>
+      <EmployeeTable employees={employees} />
     </div>
   )
 }

--- a/schema.prisma
+++ b/schema.prisma
@@ -17,6 +17,7 @@ model User {
   updatedAt    DateTime @updatedAt
 
   sessions Session[]
+  employee Employee?
 }
 
 model Session {
@@ -34,6 +35,38 @@ enum Role {
   PLANNER
   WMS
   SALES
+}
+
+model Department {
+  id        String     @id @default(cuid())
+  name      String     @unique
+  createdAt DateTime   @default(now())
+  updatedAt DateTime   @updatedAt
+  employees Employee[]
+}
+
+model JobRole {
+  id        String     @id @default(cuid())
+  name      String     @unique
+  createdAt DateTime   @default(now())
+  updatedAt DateTime   @updatedAt
+  employees Employee[]
+}
+
+model Employee {
+  id           String      @id @default(cuid())
+  firstName    String
+  lastName     String
+  email        String?
+  phone        String?
+  departmentId String?
+  roleId       String?
+  userId       String?     @unique
+  department   Department? @relation(fields: [departmentId], references: [id])
+  role         JobRole?    @relation(fields: [roleId], references: [id])
+  user         User?       @relation(fields: [userId], references: [id])
+  createdAt    DateTime    @default(now())
+  updatedAt    DateTime    @updatedAt
 }
 
 model Supplier {


### PR DESCRIPTION
## Summary
- define Department, JobRole and Employee models and relate employees to users
- add CRUD API for employees
- build HR pages for employee listing and profile editing

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1c80e966483288b2e6540b2f1f510