### PR TITLE
Add accounting models and finance reporting

### DIFF
--- a/app/api/finance/ledger/route.ts
+++ b/app/api/finance/ledger/route.ts
@@ -1,0 +1,28 @@
+import { prisma } from '@/lib/prisma'
+import { NextResponse } from 'next/server'
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const accountId = searchParams.get('account')
+  if (!accountId) return NextResponse.json({ error: 'account required' }, { status: 400 })
+
+  const lines = await prisma.journalLine.findMany({
+    where: { accountId },
+    include: { entry: true, account: true },
+    orderBy: [{ entry: { date: 'asc' } }, { createdAt: 'asc' }],
+  })
+
+  let balance = 0
+  const data = lines.map(l => {
+    balance += l.debit - l.credit
+    return {
+      date: l.entry.date,
+      description: l.entry.description,
+      debit: l.debit,
+      credit: l.credit,
+      balance,
+    }
+  })
+
+  return NextResponse.json(data)
+}

--- a/app/api/finance/trial-balance/route.ts
+++ b/app/api/finance/trial-balance/route.ts
@@ -1,0 +1,17 @@
+import { prisma } from '@/lib/prisma'
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  const accounts = await prisma.account.findMany({
+    include: { lines: true },
+    orderBy: { code: 'asc' },
+  })
+
+  const data = accounts.map(acc => {
+    const debit = acc.lines.reduce((s, l) => s + l.debit, 0)
+    const credit = acc.lines.reduce((s, l) => s + l.credit, 0)
+    return { id: acc.id, code: acc.code, name: acc.name, debit, credit, balance: debit - credit }
+  })
+
+  return NextResponse.json(data)
+}

--- a/app/api/purchases/[id]/finalize/route.ts
+++ b/app/api/purchases/[id]/finalize/route.ts
@@ -1,0 +1,50 @@
+import { prisma } from '@/lib/prisma'
+import { NextResponse } from 'next/server'
+
+async function ensureAccount(code: string, name: string, type: any) {
+  await prisma.account.upsert({
+    where: { code },
+    update: {},
+    create: { code, name, type },
+  })
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const order = await prisma.purchaseOrder.findUnique({
+      where: { id: params.id },
+      include: { lines: true },
+    })
+    if (!order) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+    const total = order.lines.reduce((sum, l) => sum + l.qty * l.unitCost, 0)
+
+    await ensureAccount('INV', 'Inventory', 'ASSET')
+    await ensureAccount('AP', 'Accounts Payable', 'LIABILITY')
+
+    await prisma.$transaction([
+      prisma.purchaseOrder.update({
+        where: { id: order.id },
+        data: { status: 'RECEIVED' },
+      }),
+      prisma.journalEntry.create({
+        data: {
+          description: `Purchase order ${order.orderNo}`,
+          lines: {
+            create: [
+              { account: { connect: { code: 'INV' } }, debit: total },
+              { account: { connect: { code: 'AP' } }, credit: total },
+            ],
+          },
+        },
+      }),
+    ])
+
+    return NextResponse.json({ ok: true })
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  }
+}

--- a/app/api/purchases/route.ts
+++ b/app/api/purchases/route.ts
@@ -1,0 +1,48 @@
+import { prisma } from '@/lib/prisma'
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+const lineSchema = z.object({
+  itemId: z.string().min(1),
+  qty: z.number().positive(),
+  unitCost: z.number().nonnegative(),
+})
+
+const schema = z.object({
+  orderNo: z.string().min(1),
+  supplierName: z.string().min(1),
+  lines: z.array(lineSchema).min(1),
+})
+
+export async function GET() {
+  const orders = await prisma.purchaseOrder.findMany({
+    include: { supplier: true, lines: { include: { item: true } } },
+    orderBy: { createdAt: 'desc' },
+  })
+  return NextResponse.json(orders)
+}
+
+export async function POST(req: Request) {
+  const data = await req.json()
+  const parsed = schema.safeParse(data)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.format() }, { status: 400 })
+  try {
+    const supplier = await prisma.supplier.findFirst({ where: { name: parsed.data.supplierName } })
+    const supplierId = supplier
+      ? supplier.id
+      : (await prisma.supplier.create({ data: { name: parsed.data.supplierName } })).id
+    const order = await prisma.purchaseOrder.create({
+      data: {
+        orderNo: parsed.data.orderNo,
+        supplierId,
+        lines: {
+          create: parsed.data.lines.map(l => ({ itemId: l.itemId, qty: l.qty, uom: 'ea', unitCost: l.unitCost })),
+        },
+      },
+      include: { supplier: true, lines: { include: { item: true } } },
+    })
+    return NextResponse.json(order)
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  }
+}

--- a/app/api/sales/[id]/finalize/route.ts
+++ b/app/api/sales/[id]/finalize/route.ts
@@ -1,0 +1,50 @@
+import { prisma } from '@/lib/prisma'
+import { NextResponse } from 'next/server'
+
+async function ensureAccount(code: string, name: string, type: any) {
+  await prisma.account.upsert({
+    where: { code },
+    update: {},
+    create: { code, name, type },
+  })
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const order = await prisma.salesOrder.findUnique({
+      where: { id: params.id },
+      include: { lines: true },
+    })
+    if (!order) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+    const total = order.lines.reduce((sum, l) => sum + l.qty * l.unitPrice, 0)
+
+    await ensureAccount('AR', 'Accounts Receivable', 'ASSET')
+    await ensureAccount('SALES', 'Sales Revenue', 'REVENUE')
+
+    await prisma.$transaction([
+      prisma.salesOrder.update({
+        where: { id: order.id },
+        data: { status: 'INVOICED' },
+      }),
+      prisma.journalEntry.create({
+        data: {
+          description: `Sales order ${order.orderNo}`,
+          lines: {
+            create: [
+              { account: { connect: { code: 'AR' } }, debit: total },
+              { account: { connect: { code: 'SALES' } }, credit: total },
+            ],
+          },
+        },
+      }),
+    ])
+
+    return NextResponse.json({ ok: true })
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  }
+}

--- a/app/finance/ledger/page.tsx
+++ b/app/finance/ledger/page.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+
+export default function LedgerPage() {
+  const [accounts, setAccounts] = useState<any[]>([])
+  const [accountId, setAccountId] = useState('')
+  const [lines, setLines] = useState<any[]>([])
+
+  useEffect(() => {
+    axios.get('/api/finance/trial-balance').then(res => setAccounts(res.data))
+  }, [])
+
+  async function load() {
+    if (!accountId) return
+    const res = await axios.get('/api/finance/ledger?account=' + accountId)
+    setLines(res.data)
+  }
+
+  return (
+    <div>
+      <h1 className="text-xl font-bold mb-4">General Ledger</h1>
+      <div className="mb-4 flex gap-2">
+        <select className="input" value={accountId} onChange={e => setAccountId(e.target.value)}>
+          <option value="">Select account</option>
+          {accounts.map(a => (
+            <option key={a.id} value={a.id}>{a.code} - {a.name}</option>
+          ))}
+        </select>
+        <button className="btn" onClick={load}>Load</button>
+      </div>
+      <table className="table">
+        <thead>
+          <tr>
+            <th className="th">Date</th>
+            <th className="th">Description</th>
+            <th className="th">Debit</th>
+            <th className="th">Credit</th>
+            <th className="th">Balance</th>
+          </tr>
+        </thead>
+        <tbody>
+          {lines.map((l, idx) => (
+            <tr key={idx}>
+              <td className="td">{new Date(l.date).toISOString().slice(0,10)}</td>
+              <td className="td">{l.description}</td>
+              <td className="td">{l.debit.toFixed(2)}</td>
+              <td className="td">{l.credit.toFixed(2)}</td>
+              <td className="td">{l.balance.toFixed(2)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/app/finance/page.tsx
+++ b/app/finance/page.tsx
@@ -1,8 +1,13 @@
+import Link from 'next/link'
+
 export default function Page() {
   return (
     <div>
       <h1 className="text-xl font-bold mb-4">Finance Module</h1>
-      <p>Placeholder page for the Finance module.</p>
+      <ul className="list-disc pl-5 space-y-2">
+        <li><Link href="/finance/trial-balance">Trial Balance</Link></li>
+        <li><Link href="/finance/ledger">General Ledger</Link></li>
+      </ul>
     </div>
   )
 }

--- a/app/finance/trial-balance/page.tsx
+++ b/app/finance/trial-balance/page.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+
+export default function TrialBalancePage() {
+  const [rows, setRows] = useState<any[]>([])
+
+  useEffect(() => {
+    axios.get('/api/finance/trial-balance').then(res => setRows(res.data))
+  }, [])
+
+  return (
+    <div>
+      <h1 className="text-xl font-bold mb-4">Trial Balance</h1>
+      <table className="table">
+        <thead>
+          <tr>
+            <th className="th">Account</th>
+            <th className="th">Debit</th>
+            <th className="th">Credit</th>
+            <th className="th">Balance</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(r => (
+            <tr key={r.id}>
+              <td className="td">{r.code} - {r.name}</td>
+              <td className="td">{r.debit.toFixed(2)}</td>
+              <td className="td">{r.credit.toFixed(2)}</td>
+              <td className="td">{r.balance.toFixed(2)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/schema.prisma
+++ b/schema.prisma
@@ -37,15 +37,16 @@ enum Role {
 }
 
 model Supplier {
-  id        String   @id @default(cuid())
-  name      String
-  email     String?
-  phone     String?
-  address   String?
-  score     Int      @default(0)
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  items     Item[]
+  id            String          @id @default(cuid())
+  name          String
+  email         String?
+  phone         String?
+  address       String?
+  score         Int             @default(0)
+  createdAt     DateTime        @default(now())
+  updatedAt     DateTime        @updatedAt
+  items         Item[]
+  PurchaseOrder PurchaseOrder[]
 }
 
 model Customer {
@@ -95,13 +96,14 @@ model Item {
   createdAt  DateTime     @default(now())
   updatedAt  DateTime     @updatedAt
 
-  specs        Spec[]
-  lots         InventoryLot[]
-  bomParents   BOMLine[]         @relation("BOMItemParent")
-  bomChildOf   BOMLine[]         @relation("BOMItemChild")
-  formulations Formulation[]
-  batches      ProductionBatch[]
-  salesLines   SalesOrderLine[]
+  specs             Spec[]
+  lots              InventoryLot[]
+  bomParents        BOMLine[]           @relation("BOMItemParent")
+  bomChildOf        BOMLine[]           @relation("BOMItemChild")
+  formulations      Formulation[]
+  batches           ProductionBatch[]
+  salesLines        SalesOrderLine[]
+  PurchaseOrderLine PurchaseOrderLine[]
 }
 
 enum ItemCategory {
@@ -256,4 +258,70 @@ model COA {
   lot       InventoryLot @relation(fields: [lotId], references: [id], onDelete: Cascade)
   url       String? // link to PDF stored elsewhere
   createdAt DateTime     @default(now())
+}
+
+// Accounting Models
+
+enum AccountType {
+  ASSET
+  LIABILITY
+  EQUITY
+  REVENUE
+  EXPENSE
+}
+
+model Account {
+  id        String        @id @default(cuid())
+  code      String        @unique
+  name      String
+  type      AccountType
+  createdAt DateTime      @default(now())
+  updatedAt DateTime      @updatedAt
+  lines     JournalLine[]
+}
+
+model JournalEntry {
+  id          String        @id @default(cuid())
+  date        DateTime      @default(now())
+  description String?
+  createdAt   DateTime      @default(now())
+  lines       JournalLine[]
+}
+
+model JournalLine {
+  id        String       @id @default(cuid())
+  entryId   String
+  accountId String
+  debit     Float        @default(0)
+  credit    Float        @default(0)
+  entry     JournalEntry @relation(fields: [entryId], references: [id], onDelete: Cascade)
+  account   Account      @relation(fields: [accountId], references: [id], onDelete: Cascade)
+}
+
+enum POStatus {
+  DRAFT
+  RECEIVED
+  INVOICED
+}
+
+model PurchaseOrder {
+  id         String              @id @default(cuid())
+  orderNo    String              @unique
+  supplierId String
+  supplier   Supplier            @relation(fields: [supplierId], references: [id], onDelete: Cascade)
+  status     POStatus            @default(DRAFT)
+  createdAt  DateTime            @default(now())
+  updatedAt  DateTime            @updatedAt
+  lines      PurchaseOrderLine[]
+}
+
+model PurchaseOrderLine {
+  id       String        @id @default(cuid())
+  orderId  String
+  itemId   String
+  qty      Float
+  uom      String
+  unitCost Float
+  order    PurchaseOrder @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  item     Item          @relation(fields: [itemId], references: [id])
 }


### PR DESCRIPTION
## Summary
- extend Prisma schema with Account, JournalEntry, JournalLine, and purchase order models
- post journal entries when sales or purchase orders are finalized
- expose finance API endpoints and pages for trial balance and general ledger

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1c80bf6d48328aaa2209e50bb9227