### PR TITLE
feat: add purchase order models and UI

### DIFF
--- a/PurchaseOrderForm.tsx
+++ b/PurchaseOrderForm.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { useState } from 'react'
+import axios from 'axios'
+
+export default function PurchaseOrderForm() {
+  const [form, setForm] = useState({
+    orderNo: '',
+    supplierId: '',
+    itemId: '',
+    qty: '',
+    uom: 'kg',
+    lotNumber: ''
+  })
+  const [loading, setLoading] = useState(false)
+  const [msg, setMsg] = useState<string | null>(null)
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    setLoading(true)
+    setMsg(null)
+    const res = await axios.post('/api/purchases', {
+      orderNo: form.orderNo,
+      supplierId: form.supplierId,
+      lines: [
+        {
+          itemId: form.itemId,
+          qty: Number(form.qty),
+          uom: form.uom,
+          lotNumber: form.lotNumber
+        }
+      ]
+    })
+    setLoading(false)
+    if (res.status === 200) {
+      setMsg('Created')
+      setForm({ orderNo: '', supplierId: '', itemId: '', qty: '', uom: 'kg', lotNumber: '' })
+      window.location.reload()
+    } else setMsg('Failed')
+  }
+
+  return (
+    <form onSubmit={submit} className="space-y-3">
+      <div>
+        <label className="label">Order No</label>
+        <input className="input" value={form.orderNo} onChange={e=>setForm({...form, orderNo:e.target.value})} required />
+      </div>
+      <div>
+        <label className="label">Supplier ID</label>
+        <input className="input" value={form.supplierId} onChange={e=>setForm({...form, supplierId:e.target.value})} required />
+      </div>
+      <div>
+        <label className="label">Item ID</label>
+        <input className="input" value={form.itemId} onChange={e=>setForm({...form, itemId:e.target.value})} required />
+      </div>
+      <div>
+        <label className="label">Quantity</label>
+        <input className="input" type="number" value={form.qty} onChange={e=>setForm({...form, qty:e.target.value})} required />
+      </div>
+      <div>
+        <label className="label">UOM</label>
+        <input className="input" value={form.uom} onChange={e=>setForm({...form, uom:e.target.value})} />
+      </div>
+      <div>
+        <label className="label">Lot Number</label>
+        <input className="input" value={form.lotNumber} onChange={e=>setForm({...form, lotNumber:e.target.value})} required />
+      </div>
+      <button className="btn" disabled={loading}>{loading ? 'Saving...' : 'Save Purchase'}</button>
+      {msg && <div className="text-sm text-gray-500">{msg}</div>}
+    </form>
+  )
+}

--- a/PurchaseOrderTable.tsx
+++ b/PurchaseOrderTable.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { PurchaseOrder, Supplier, PurchaseOrderLine, Item } from '@prisma/client'
+import axios from 'axios'
+
+type Order = PurchaseOrder & { supplier: Supplier, lines: (PurchaseOrderLine & { item: Item })[] }
+
+export default function PurchaseOrderTable({ orders }: { orders: Order[] }) {
+  async function receive(id: string) {
+    await axios.put('/api/purchases', { id, status: 'RECEIVED' })
+    window.location.reload()
+  }
+  return (
+    <table className="table">
+      <thead>
+        <tr>
+          <th className="th">Order No</th>
+          <th className="th">Supplier</th>
+          <th className="th">Status</th>
+          <th className="th">Lines</th>
+          <th className="th">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {orders.map(o => (
+          <tr key={o.id} className="hover:bg-gray-50">
+            <td className="td">{o.orderNo}</td>
+            <td className="td">{o.supplier?.name}</td>
+            <td className="td">{o.status}</td>
+            <td className="td">
+              {o.lines.map(l => (
+                <div key={l.id}>{l.item?.sku} ({l.qty} {l.uom})</div>
+              ))}
+            </td>
+            <td className="td">
+              {o.status !== 'RECEIVED' && (
+                <button className="btn" onClick={() => receive(o.id)}>Receive</button>
+              )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}

--- a/app/api/purchases/route.ts
+++ b/app/api/purchases/route.ts
@@ -1,0 +1,102 @@
+import { prisma } from '@/lib/prisma'
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { POStatus } from '@prisma/client'
+
+const lineSchema = z.object({
+  itemId: z.string().min(1),
+  qty: z.number(),
+  uom: z.string().min(1),
+  lotNumber: z.string().min(1)
+})
+
+const createSchema = z.object({
+  orderNo: z.string().min(1),
+  supplierId: z.string().min(1),
+  lines: z.array(lineSchema)
+})
+
+export async function GET() {
+  const orders = await prisma.purchaseOrder.findMany({
+    include: { supplier: true, lines: { include: { item: true } } },
+    orderBy: { createdAt: 'desc' }
+  })
+  return NextResponse.json(orders)
+}
+
+export async function POST(req: Request) {
+  const data = await req.json()
+  const parsed = createSchema.safeParse({
+    ...data,
+    lines: data.lines?.map((l: any) => ({ ...l, qty: Number(l.qty) }))
+  })
+  if (!parsed.success)
+    return NextResponse.json({ error: parsed.error.format() }, { status: 400 })
+  try {
+    const order = await prisma.purchaseOrder.create({
+      data: {
+        orderNo: parsed.data.orderNo,
+        supplierId: parsed.data.supplierId,
+        lines: { create: parsed.data.lines }
+      },
+      include: { supplier: true, lines: { include: { item: true } } }
+    })
+    return NextResponse.json(order)
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  }
+}
+
+const updateSchema = z.object({
+  id: z.string().min(1),
+  status: z.nativeEnum(POStatus)
+})
+
+export async function PUT(req: Request) {
+  const data = await req.json()
+  const parsed = updateSchema.safeParse(data)
+  if (!parsed.success)
+    return NextResponse.json({ error: parsed.error.format() }, { status: 400 })
+  try {
+    const existing = await prisma.purchaseOrder.findUnique({
+      where: { id: parsed.data.id },
+      include: { lines: true }
+    })
+    if (!existing)
+      return NextResponse.json({ error: 'Not found' }, { status: 404 })
+    const updated = await prisma.purchaseOrder.update({
+      where: { id: parsed.data.id },
+      data: { status: parsed.data.status }
+    })
+    if (
+      parsed.data.status === 'RECEIVED' &&
+      existing.status !== 'RECEIVED'
+    ) {
+      const lotData = existing.lines.map((l) => ({
+        itemId: l.itemId,
+        lotNumber: l.lotNumber,
+        qty: l.qty,
+        uom: l.uom
+      }))
+      if (lotData.length) await prisma.inventoryLot.createMany({ data: lotData })
+    }
+    return NextResponse.json(updated)
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  }
+}
+
+const deleteSchema = z.object({ id: z.string().min(1) })
+
+export async function DELETE(req: Request) {
+  const data = await req.json()
+  const parsed = deleteSchema.safeParse(data)
+  if (!parsed.success)
+    return NextResponse.json({ error: parsed.error.format() }, { status: 400 })
+  try {
+    await prisma.purchaseOrder.delete({ where: { id: parsed.data.id } })
+    return NextResponse.json({ success: true })
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  }
+}

--- a/app/purchases/page.tsx
+++ b/app/purchases/page.tsx
@@ -1,0 +1,27 @@
+import PurchaseOrderForm from '@/PurchaseOrderForm'
+import PurchaseOrderTable from '@/PurchaseOrderTable'
+import { prisma } from '@/lib/prisma'
+
+async function loadOrders() {
+  try {
+    return await prisma.purchaseOrder.findMany({
+      include: { supplier: true, lines: { include: { item: true } } },
+      orderBy: { createdAt: 'desc' }
+    })
+  } catch {
+    return []
+  }
+}
+
+export default async function Page() {
+  const orders = await loadOrders()
+  return (
+    <div>
+      <h1 className="text-xl font-bold mb-4">Purchase Orders</h1>
+      <div className="mb-8">
+        <PurchaseOrderForm />
+      </div>
+      <PurchaseOrderTable orders={orders} />
+    </div>
+  )
+}

--- a/schema.prisma
+++ b/schema.prisma
@@ -46,6 +46,36 @@ model Supplier {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   items     Item[]
+  purchaseOrders PurchaseOrder[]
+}
+
+model PurchaseOrder {
+  id         String      @id @default(cuid())
+  orderNo    String      @unique
+  supplierId String
+  supplier   Supplier    @relation(fields: [supplierId], references: [id])
+  status     POStatus    @default(DRAFT)
+  createdAt  DateTime    @default(now())
+  updatedAt  DateTime    @updatedAt
+  lines      PurchaseOrderLine[]
+}
+
+enum POStatus {
+  DRAFT
+  ORDERED
+  RECEIVED
+  CANCELLED
+}
+
+model PurchaseOrderLine {
+  id        String        @id @default(cuid())
+  orderId   String
+  order     PurchaseOrder @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  itemId    String
+  item      Item          @relation(fields: [itemId], references: [id])
+  qty       Float
+  uom       String
+  lotNumber String
 }
 
 model Customer {
@@ -102,6 +132,7 @@ model Item {
   formulations Formulation[]
   batches      ProductionBatch[]
   salesLines   SalesOrderLine[]
+  purchaseLines PurchaseOrderLine[]
 }
 
 enum ItemCategory {


### PR DESCRIPTION
## Summary
- define PurchaseOrder and PurchaseOrderLine models
- implement purchases API with CRUD and inventory lot creation
- add purchase orders UI with form, table, and receiving action

## Testing
- `npx prisma migrate dev --name add_purchase_models` *(fails: Environment variable not found: DATABASE_URL)*
- `npx prisma generate`
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b1c80a46cc8328b697ae2bd7871523