### PR TITLE
feat: add editing for items and suppliers

### DIFF
--- a/ItemTable.tsx
+++ b/ItemTable.tsx
@@ -1,30 +1,118 @@
 'use client'
+import { useState } from 'react'
+import axios from 'axios'
 import { Item, ItemCategory } from '@prisma/client'
 
 export default function ItemTable({ items }: { items: Item[] }) {
-  const cat = (c: ItemCategory) => c.replace('_',' ')
+  const cat = (c: ItemCategory) => c.replace('_', ' ')
+  const [editing, setEditing] = useState<Item | null>(null)
+  const [form, setForm] = useState({ sku: '', name: '', category: 'RAW_MATERIAL', uom: '', isActive: true })
+  const [loading, setLoading] = useState(false)
+  const [msg, setMsg] = useState<string | null>(null)
+
+  function startEdit(item: Item) {
+    setEditing(item)
+    setForm({ sku: item.sku, name: item.name, category: item.category, uom: item.uom, isActive: item.isActive })
+    setMsg(null)
+  }
+
+  async function save(e: React.FormEvent) {
+    e.preventDefault()
+    if (!editing) return
+    setLoading(true); setMsg(null)
+    try {
+      const res = await axios.put('/api/items', { id: editing.id, ...form })
+      if (res.status === 200) {
+        setEditing(null)
+        window.location.reload()
+      }
+    } catch (err: any) {
+      setMsg(err.response?.data?.error || 'Failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function remove(id: string) {
+    if (!confirm('Delete this item?')) return
+    try {
+      await axios.delete('/api/items', { data: { id } })
+      window.location.reload()
+    } catch (err: any) {
+      alert(err.response?.data?.error || 'Failed')
+    }
+  }
+
   return (
-    <table className="table">
-      <thead>
-        <tr>
-          <th className="th">SKU</th>
-          <th className="th">Name</th>
-          <th className="th">Category</th>
-          <th className="th">UOM</th>
-          <th className="th">Active</th>
-        </tr>
-      </thead>
-      <tbody>
-        {items.map(it => (
-          <tr key={it.id} className="hover:bg-gray-50">
-            <td className="td">{it.sku}</td>
-            <td className="td">{it.name}</td>
-            <td className="td"><span className="badge">{cat(it.category)}</span></td>
-            <td className="td">{it.uom}</td>
-            <td className="td">{it.isActive ? 'Yes':'No'}</td>
+    <div>
+      {editing && (
+        <form onSubmit={save} className="space-y-3 mb-6">
+          <div>
+            <label className="label">SKU</label>
+            <input className="input" value={form.sku} onChange={e => setForm({ ...form, sku: e.target.value })} required />
+          </div>
+          <div>
+            <label className="label">Name</label>
+            <input className="input" value={form.name} onChange={e => setForm({ ...form, name: e.target.value })} required />
+          </div>
+          <div>
+            <label className="label">Category</label>
+            <select className="input" value={form.category} onChange={e => setForm({ ...form, category: e.target.value })}>
+              <option value="RAW_MATERIAL">RAW_MATERIAL</option>
+              <option value="PACKAGING">PACKAGING</option>
+              <option value="FINISHED_GOOD">FINISHED_GOOD</option>
+              <option value="WIP">WIP</option>
+            </select>
+          </div>
+          <div>
+            <label className="label">UOM</label>
+            <input className="input" value={form.uom} onChange={e => setForm({ ...form, uom: e.target.value })} />
+          </div>
+          <div>
+            <label className="label">Active</label>
+            <select
+              className="input"
+              value={form.isActive ? 'true' : 'false'}
+              onChange={e => setForm({ ...form, isActive: e.target.value === 'true' })}
+            >
+              <option value="true">Yes</option>
+              <option value="false">No</option>
+            </select>
+          </div>
+          <div className="space-x-2">
+            <button className="btn" disabled={loading}>{loading ? 'Saving...' : 'Save'}</button>
+            <button type="button" className="btn" onClick={() => setEditing(null)}>Cancel</button>
+          </div>
+          {msg && <div className="text-sm text-gray-500">{msg}</div>}
+        </form>
+      )}
+      <table className="table">
+        <thead>
+          <tr>
+            <th className="th">SKU</th>
+            <th className="th">Name</th>
+            <th className="th">Category</th>
+            <th className="th">UOM</th>
+            <th className="th">Active</th>
+            <th className="th">Actions</th>
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {items.map(it => (
+            <tr key={it.id} className="hover:bg-gray-50">
+              <td className="td">{it.sku}</td>
+              <td className="td">{it.name}</td>
+              <td className="td"><span className="badge">{cat(it.category)}</span></td>
+              <td className="td">{it.uom}</td>
+              <td className="td">{it.isActive ? 'Yes' : 'No'}</td>
+              <td className="td space-x-2">
+                <button className="btn" onClick={() => startEdit(it)}>Edit</button>
+                <button className="btn" onClick={() => remove(it.id)}>Delete</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   )
 }

--- a/NewItemForm.tsx
+++ b/NewItemForm.tsx
@@ -11,13 +11,18 @@ export default function NewItemForm() {
   async function submit(e: React.FormEvent) {
     e.preventDefault()
     setLoading(true); setMsg(null)
-    const res = await axios.post('/api/items', form)
-    setLoading(false)
-    if (res.status === 200) {
-      setMsg('Created')
-      setForm({ sku: '', name: '', category: 'RAW_MATERIAL', uom: 'kg' })
-      window.location.reload()
-    } else setMsg('Failed')
+    try {
+      const res = await axios.post('/api/items', form)
+      if (res.status === 200) {
+        setMsg('Created')
+        setForm({ sku: '', name: '', category: 'RAW_MATERIAL', uom: 'kg' })
+        window.location.reload()
+      }
+    } catch (err: any) {
+      setMsg(err.response?.data?.error || 'Failed')
+    } finally {
+      setLoading(false)
+    }
   }
 
   return (

--- a/SupplierForm.tsx
+++ b/SupplierForm.tsx
@@ -11,13 +11,18 @@ export default function SupplierForm() {
   async function submit(e: React.FormEvent) {
     e.preventDefault()
     setLoading(true); setMsg(null)
-    const res = await axios.post('/api/suppliers', form)
-    setLoading(false)
-    if (res.status === 200) {
-      setMsg('Created')
-      setForm({ name: '', email: '', phone: '' })
-      window.location.reload()
-    } else setMsg('Failed')
+    try {
+      const res = await axios.post('/api/suppliers', form)
+      if (res.status === 200) {
+        setMsg('Created')
+        setForm({ name: '', email: '', phone: '' })
+        window.location.reload()
+      }
+    } catch (err: any) {
+      setMsg(err.response?.data?.error || 'Failed')
+    } finally {
+      setLoading(false)
+    }
   }
 
   return (

--- a/SupplierTable.tsx
+++ b/SupplierTable.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import { useState } from 'react'
+import axios from 'axios'
+import { Supplier } from '@prisma/client'
+
+export default function SupplierTable({ suppliers }: { suppliers: Supplier[] }) {
+  const [editing, setEditing] = useState<Supplier | null>(null)
+  const [form, setForm] = useState({ name: '', email: '', phone: '' })
+  const [loading, setLoading] = useState(false)
+  const [msg, setMsg] = useState<string | null>(null)
+
+  function startEdit(s: Supplier) {
+    setEditing(s)
+    setForm({ name: s.name, email: s.email || '', phone: s.phone || '' })
+    setMsg(null)
+  }
+
+  async function save(e: React.FormEvent) {
+    e.preventDefault()
+    if (!editing) return
+    setLoading(true); setMsg(null)
+    try {
+      const res = await axios.put('/api/suppliers', { id: editing.id, ...form })
+      if (res.status === 200) {
+        setEditing(null)
+        window.location.reload()
+      }
+    } catch (err: any) {
+      setMsg(err.response?.data?.error || 'Failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function remove(id: string) {
+    if (!confirm('Delete this supplier?')) return
+    try {
+      await axios.delete('/api/suppliers', { data: { id } })
+      window.location.reload()
+    } catch (err: any) {
+      alert(err.response?.data?.error || 'Failed')
+    }
+  }
+
+  return (
+    <div>
+      {editing && (
+        <form onSubmit={save} className="space-y-3 mb-6">
+          <div>
+            <label className="label">Name</label>
+            <input className="input" value={form.name} onChange={e => setForm({ ...form, name: e.target.value })} required />
+          </div>
+          <div>
+            <label className="label">Email</label>
+            <input className="input" value={form.email} onChange={e => setForm({ ...form, email: e.target.value })} />
+          </div>
+          <div>
+            <label className="label">Phone</label>
+            <input className="input" value={form.phone} onChange={e => setForm({ ...form, phone: e.target.value })} />
+          </div>
+          <div className="space-x-2">
+            <button className="btn" disabled={loading}>{loading ? 'Saving...' : 'Save'}</button>
+            <button type="button" className="btn" onClick={() => setEditing(null)}>Cancel</button>
+          </div>
+          {msg && <div className="text-sm text-gray-500">{msg}</div>}
+        </form>
+      )}
+      <table className="table">
+        <thead>
+          <tr>
+            <th className="th">Name</th>
+            <th className="th">Email</th>
+            <th className="th">Phone</th>
+            <th className="th">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {suppliers.map(s => (
+            <tr key={s.id} className="hover:bg-gray-50">
+              <td className="td">{s.name}</td>
+              <td className="td">{s.email}</td>
+              <td className="td">{s.phone}</td>
+              <td className="td space-x-2">
+                <button className="btn" onClick={() => startEdit(s)}>Edit</button>
+                <button className="btn" onClick={() => remove(s.id)}>Delete</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/app/api/items/route.ts
+++ b/app/api/items/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma'
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
-import { ItemCategory } from '@prisma/client'
+import { ItemCategory, Prisma } from '@prisma/client'
 
 const schema = z.object({
   sku: z.string().min(1),
@@ -23,6 +23,43 @@ export async function POST(req: Request) {
     const item = await prisma.item.create({ data: parsed.data })
     return NextResponse.json(item)
   } catch (e: any) {
+    if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
+      return NextResponse.json({ error: 'SKU must be unique' }, { status: 409 })
+    }
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  }
+}
+
+const updateSchema = schema.extend({ id: z.string().min(1), isActive: z.boolean().optional() })
+
+export async function PUT(req: Request) {
+  const data = await req.json()
+  const parsed = updateSchema.safeParse(data)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.format() }, { status: 400 })
+  try {
+    const { id, ...rest } = parsed.data
+    const item = await prisma.item.update({ where: { id }, data: rest })
+    return NextResponse.json(item)
+  } catch (e: any) {
+    if (e instanceof Prisma.PrismaClientKnownRequestError) {
+      if (e.code === 'P2002') return NextResponse.json({ error: 'SKU must be unique' }, { status: 409 })
+      if (e.code === 'P2025') return NextResponse.json({ error: 'Item not found' }, { status: 404 })
+    }
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  }
+}
+
+export async function DELETE(req: Request) {
+  const data = await req.json()
+  const parsed = z.object({ id: z.string().min(1) }).safeParse(data)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.format() }, { status: 400 })
+  try {
+    await prisma.item.delete({ where: { id: parsed.data.id } })
+    return NextResponse.json({ success: true })
+  } catch (e: any) {
+    if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2025') {
+      return NextResponse.json({ error: 'Item not found' }, { status: 404 })
+    }
     return NextResponse.json({ error: e.message }, { status: 500 })
   }
 }

--- a/app/api/suppliers/route.ts
+++ b/app/api/suppliers/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/lib/prisma'
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
+import { Prisma } from '@prisma/client'
 
 const schema = z.object({
   name: z.string().min(1),
@@ -16,6 +17,43 @@ export async function POST(req: Request) {
     const supplier = await prisma.supplier.create({ data: { name: parsed.data.name, email: parsed.data.email || null, phone: parsed.data.phone || null } })
     return NextResponse.json(supplier)
   } catch (e: any) {
+    if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
+      return NextResponse.json({ error: 'Duplicate supplier' }, { status: 409 })
+    }
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  }
+}
+
+const updateSchema = schema.extend({ id: z.string().min(1) })
+
+export async function PUT(req: Request) {
+  const data = await req.json()
+  const parsed = updateSchema.safeParse(data)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.format() }, { status: 400 })
+  try {
+    const { id, ...rest } = parsed.data
+    const supplier = await prisma.supplier.update({ where: { id }, data: { ...rest, email: rest.email || null, phone: rest.phone || null } })
+    return NextResponse.json(supplier)
+  } catch (e: any) {
+    if (e instanceof Prisma.PrismaClientKnownRequestError) {
+      if (e.code === 'P2002') return NextResponse.json({ error: 'Duplicate supplier' }, { status: 409 })
+      if (e.code === 'P2025') return NextResponse.json({ error: 'Supplier not found' }, { status: 404 })
+    }
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  }
+}
+
+export async function DELETE(req: Request) {
+  const data = await req.json()
+  const parsed = z.object({ id: z.string().min(1) }).safeParse(data)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.format() }, { status: 400 })
+  try {
+    await prisma.supplier.delete({ where: { id: parsed.data.id } })
+    return NextResponse.json({ success: true })
+  } catch (e: any) {
+    if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2025') {
+      return NextResponse.json({ error: 'Supplier not found' }, { status: 404 })
+    }
     return NextResponse.json({ error: e.message }, { status: 500 })
   }
 }

--- a/app/suppliers/page.tsx
+++ b/app/suppliers/page.tsx
@@ -1,4 +1,5 @@
 import SupplierForm from '@/SupplierForm'
+import SupplierTable from '@/SupplierTable'
 import { prisma } from '@/lib/prisma'
 
 async function loadSuppliers() {
@@ -17,24 +18,7 @@ export default async function Page() {
       <div className="mb-8">
         <SupplierForm />
       </div>
-      <table className="table">
-        <thead>
-          <tr>
-            <th className="th">Name</th>
-            <th className="th">Email</th>
-            <th className="th">Phone</th>
-          </tr>
-        </thead>
-        <tbody>
-          {suppliers.map(s => (
-            <tr key={s.id} className="hover:bg-gray-50">
-              <td className="td">{s.name}</td>
-              <td className="td">{s.email}</td>
-              <td className="td">{s.phone}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <SupplierTable suppliers={suppliers} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add PUT/DELETE handlers for items and suppliers with Prisma error handling
- allow editing and deleting items and suppliers through new table forms
- surface API errors on create forms

## Testing
- `npm test`
- `DATABASE_URL="mysql://user:pass@localhost:3306/db" npm run build > /tmp/build.log 2>&1 && tail -n 20 /tmp/build.log`


------
https://chatgpt.com/codex/tasks/task_e_68b1c81b5a5c8328bb7be8099b93e51d