### PR TITLE
feat: add role-based access control

### DIFF
--- a/app/api/batches/route.ts
+++ b/app/api/batches/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/lib/prisma'
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
+import { getToken } from 'next-auth/jwt'
 
 const schema = z.object({
   fgItemId: z.string().min(1),
@@ -9,7 +10,11 @@ const schema = z.object({
   uom: z.string().min(1)
 })
 
-export async function GET() {
+export async function GET(req: NextRequest) {
+  const token = await getToken({ req })
+  if (!token || token.role !== 'ADMIN') {
+    return new NextResponse('Forbidden', { status: 403 })
+  }
   const batches = await prisma.productionBatch.findMany({
     include: { fgItem: true },
     orderBy: { createdAt: 'desc' }
@@ -17,7 +22,11 @@ export async function GET() {
   return NextResponse.json(batches)
 }
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
+  const token = await getToken({ req })
+  if (!token || token.role !== 'ADMIN') {
+    return new NextResponse('Forbidden', { status: 403 })
+  }
   const data = await req.json()
   const parsed = schema.safeParse({ ...data, plannedQty: Number(data.plannedQty) })
   if (!parsed.success) return NextResponse.json({ error: parsed.error.format() }, { status: 400 })

--- a/app/api/items/route.ts
+++ b/app/api/items/route.ts
@@ -1,7 +1,8 @@
 import { prisma } from '@/lib/prisma'
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { ItemCategory } from '@prisma/client'
+import { getToken } from 'next-auth/jwt'
 
 const schema = z.object({
   sku: z.string().min(1),
@@ -10,12 +11,20 @@ const schema = z.object({
   uom: z.string().min(1)
 })
 
-export async function GET() {
+export async function GET(req: NextRequest) {
+  const token = await getToken({ req })
+  if (!token || token.role !== 'ADMIN') {
+    return new NextResponse('Forbidden', { status: 403 })
+  }
   const items = await prisma.item.findMany({ orderBy: { createdAt: 'desc' } })
   return NextResponse.json(items)
 }
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
+  const token = await getToken({ req })
+  if (!token || token.role !== 'ADMIN') {
+    return new NextResponse('Forbidden', { status: 403 })
+  }
   const data = await req.json()
   const parsed = schema.safeParse(data)
   if (!parsed.success) return NextResponse.json({ error: parsed.error.format() }, { status: 400 })

--- a/app/api/suppliers/route.ts
+++ b/app/api/suppliers/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/lib/prisma'
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
+import { getToken } from 'next-auth/jwt'
 
 const schema = z.object({
   name: z.string().min(1),
@@ -8,7 +9,11 @@ const schema = z.object({
   phone: z.string().optional().or(z.literal(''))
 })
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
+  const token = await getToken({ req })
+  if (!token || token.role !== 'ADMIN') {
+    return new NextResponse('Forbidden', { status: 403 })
+  }
   const data = await req.json()
   const parsed = schema.safeParse(data)
   if (!parsed.success) return NextResponse.json({ error: parsed.error.format() }, { status: 400 })
@@ -20,7 +25,11 @@ export async function POST(req: Request) {
   }
 }
 
-export async function GET() {
+export async function GET(req: NextRequest) {
+  const token = await getToken({ req })
+  if (!token || token.role !== 'ADMIN') {
+    return new NextResponse('Forbidden', { status: 403 })
+  }
   const suppliers = await prisma.supplier.findMany({ orderBy: { createdAt: 'desc' } })
   return NextResponse.json(suppliers)
 }

--- a/app/items/page.tsx
+++ b/app/items/page.tsx
@@ -1,6 +1,7 @@
 import ItemTable from '@/ItemTable'
 import NewItemForm from '@/NewItemForm'
 import { prisma } from '@/lib/prisma'
+import { auth } from '@/auth'
 
 async function loadItems() {
   try {
@@ -11,6 +12,11 @@ async function loadItems() {
 }
 
 export default async function Page() {
+  const role = (await auth())?.user.role
+  if (role !== 'ADMIN') {
+    return new Response('Forbidden', { status: 403 })
+  }
+
   const items = await loadItems()
   return (
     <div>

--- a/app/manufacturing/page.tsx
+++ b/app/manufacturing/page.tsx
@@ -1,6 +1,7 @@
 import BatchForm from '@/BatchForm'
 import BatchTable from '@/BatchTable'
 import { prisma } from '@/lib/prisma'
+import { auth } from '@/auth'
 
 async function loadBatches() {
   try {
@@ -14,6 +15,11 @@ async function loadBatches() {
 }
 
 export default async function Page() {
+  const role = (await auth())?.user.role
+  if (role !== 'ADMIN') {
+    return new Response('Forbidden', { status: 403 })
+  }
+
   const batches = await loadBatches()
   return (
     <div>

--- a/app/sales/page.tsx
+++ b/app/sales/page.tsx
@@ -1,5 +1,6 @@
 import SalesOrderForm from './SalesOrderForm'
 import { prisma } from '@/lib/prisma'
+import { auth } from '@/auth'
 
 async function loadOrders() {
   try {
@@ -13,6 +14,11 @@ async function loadOrders() {
 }
 
 export default async function Page() {
+  const role = (await auth())?.user.role
+  if (role !== 'ADMIN') {
+    return new Response('Forbidden', { status: 403 })
+  }
+
   const orders = await loadOrders()
 
   return (

--- a/app/suppliers/page.tsx
+++ b/app/suppliers/page.tsx
@@ -1,5 +1,6 @@
 import SupplierForm from '@/SupplierForm'
 import { prisma } from '@/lib/prisma'
+import { auth } from '@/auth'
 
 async function loadSuppliers() {
   try {
@@ -10,6 +11,11 @@ async function loadSuppliers() {
 }
 
 export default async function Page() {
+  const role = (await auth())?.user.role
+  if (role !== 'ADMIN') {
+    return new Response('Forbidden', { status: 403 })
+  }
+
   const suppliers = await loadSuppliers()
   return (
     <div>


### PR DESCRIPTION
## Summary
- enforce admin-only access in server pages using `(await auth()).user.role`
- require admin role for API routes and return HTTP 403 on unauthorized requests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1c81d8adc83289f5e1fbf2fad8eba