### PR TITLE
Add placeholder modules for quality, maintenance, and recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # PetFood ERP (Next.js + Prisma + MySQL)
 
-A production-grade starter tailored for pet-food manufacturing ERP. It implements authentication, RBAC (role on user), and 3 live modules (Items, Suppliers, Inventory Lots) you can extend to cover formulation, QC, batches, sales, etc.
+A production-grade starter tailored for pet-food manufacturing ERP. It implements authentication, RBAC (role on user), and 3 live modules (Items, Suppliers, Inventory Lots) you can extend to cover formulation, QC, batches, sales, etc. The starter now also includes placeholder Quality Control, Maintenance, and Recipe Management modules that demonstrate how to separate UI components from business logic functions.
 
 ## Tech
 - Next.js App Router (TypeScript), Tailwind
 - NextAuth (Credentials) with JWT sessions
 - Prisma ORM (MySQL) — works on XAMPP MySQL or Hostinger
-- Clean modules: Items, Suppliers, Inventory Lots
+- Clean modules: Items, Suppliers, Inventory Lots, Quality, Maintenance, Recipes
 
 ## Environment Variables
 The application relies on the following variables:

--- a/app/maintenance/page.tsx
+++ b/app/maintenance/page.tsx
@@ -1,0 +1,11 @@
+import { getMaintenanceStatus } from '../../lib/maintenance';
+
+export default function MaintenancePage() {
+  const status = getMaintenanceStatus();
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-2">Maintenance</h1>
+      <p>{status}</p>
+    </div>
+  );
+}

--- a/app/quality/page.tsx
+++ b/app/quality/page.tsx
@@ -1,0 +1,11 @@
+import { getQualityStatus } from '../../lib/quality';
+
+export default function QualityPage() {
+  const status = getQualityStatus();
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-2">Quality Control</h1>
+      <p>{status}</p>
+    </div>
+  );
+}

--- a/app/recipe/page.tsx
+++ b/app/recipe/page.tsx
@@ -1,0 +1,11 @@
+import { getRecipeStatus } from '../../lib/recipe';
+
+export default function RecipePage() {
+  const status = getRecipeStatus();
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-2">Recipe Management</h1>
+      <p>{status}</p>
+    </div>
+  );
+}

--- a/lib/maintenance.ts
+++ b/lib/maintenance.ts
@@ -1,0 +1,4 @@
+export function getMaintenanceStatus(): string {
+  // Placeholder business logic for maintenance module
+  return 'Maintenance module ready';
+}

--- a/lib/quality.ts
+++ b/lib/quality.ts
@@ -1,0 +1,4 @@
+export function getQualityStatus(): string {
+  // Placeholder business logic for quality control
+  return 'Quality module ready';
+}

--- a/lib/recipe.ts
+++ b/lib/recipe.ts
@@ -1,0 +1,4 @@
+export function getRecipeStatus(): string {
+  // Placeholder business logic for recipe management
+  return 'Recipe module ready';
+}


### PR DESCRIPTION
## Summary
- scaffold Quality Control, Maintenance, and Recipe Management modules with separate UI pages and business logic helpers
- document new module placeholders in README

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1ce0ebda08328b2edfadd87819b5c